### PR TITLE
dp-iverksett har byttet navn til utsjekk, kjører i nytt namespace og har ny pakke for kontrakter

### DIFF
--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -50,6 +50,6 @@ spec:
           cluster: {{ cluster }}
     outbound:
       rules:
-        - application: dp-iverksett
-          namespace: teamdagpenger
+        - application: utsjekk
+          namespace: helved
       external:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ tiltakspenger-utbetaling
 
 tiltakspenger-utbetaling er en backend tjeneste som skal håndtere beregning og utbetaling til tiltakspenger.
 
-Denne appen skal snakke med "dp-iversett" appen i utgangspunktet som igjen vil snakke med OS/UR (økonomi sin tjeneste) for å gjennomføre utbetalingen.
+Denne appen skal snakke med "utsjekk" appen i utgangspunktet som igjen vil snakke med OS/UR (økonomi sin tjeneste) for å gjennomføre utbetalingen.
 
-Appen skal innhente de dagene bruker har gått på et tiltak fra meldekortet og så sender info om utbetalingen/behandlingen til dp-iverksett. 
+Appen skal innhente de dagene bruker har gått på et tiltak fra meldekortet og så sender info om utbetalingen/behandlingen til utsjekk. 
 
 En del av satsningen ["Flere i arbeid – P4"](https://memu.no/artikler/stor-satsing-skal-fornye-navs-utdaterte-it-losninger-og-digitale-verktoy/)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ val ktorVersjon = "2.3.7"
 val jacksonVersjon = "2.16.1"
 val kotestVersjon = "5.8.0"
 val tokenSupportVersjon = "3.2.0"
-val iverksettVersjon = "3.0_20240314121254_de10ebc"
+val iverksettVersjon = "1.0_20240408113510_4a2db84"
 val flywayVersjon = "10.6.0"
 val testContainersVersion = "1.19.4"
 val kotlinxCoroutinesVersion = "1.7.3"
@@ -37,7 +37,7 @@ dependencies {
     implementation("com.natpryce:konfig:1.6.10.0")
     implementation("com.aallam.ulid:ulid-kotlin:1.3.0")
 
-    implementation("no.nav.dagpenger.kontrakter:iverksett:$iverksettVersjon")
+    implementation("no.nav.utsjekk.kontrakter:iverksett:$iverksettVersjon")
 
     implementation("io.ktor:ktor-server-netty:$ktorVersjon")
     implementation("io.ktor:ktor-serialization-jackson:$ktorVersjon")

--- a/src/main/kotlin/no/nav/tiltakspenger/utbetaling/Configuration.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/utbetaling/Configuration.kt
@@ -61,16 +61,16 @@ object Configuration {
     private val devProperties = ConfigurationMap(
         mapOf(
             "application.profile" to Profile.DEV.toString(),
-            "IVERKSETT_SCOPE" to "api://dev-gcp.teamdagpenger.dp-iverksett/.default",
-            "IVERKSETT_URL" to "http://dp-iverksett.teamdagpenger",
+            "IVERKSETT_SCOPE" to "api://dev-gcp.helved.utsjekk/.default",
+            "IVERKSETT_URL" to "http://utsjekk.helved",
         ),
     )
 
     private val prodProperties = ConfigurationMap(
         mapOf(
             "application.profile" to Profile.PROD.toString(),
-            "IVERKSETT_SCOPE" to "api://prod-gcp.teamdagpenger.dp-iverksett/.default",
-            "IVERKSETT_URL" to "https://dp-iverksett.teamdagpenger",
+            "IVERKSETT_SCOPE" to "api://prod-gcp.helved.utsjekk/.default",
+            "IVERKSETT_URL" to "https://utsjekk.helved",
         ),
     )
 

--- a/src/main/kotlin/no/nav/tiltakspenger/utbetaling/client/iverksett/Iverksett.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/utbetaling/client/iverksett/Iverksett.kt
@@ -1,7 +1,7 @@
 package no.nav.tiltakspenger.utbetaling.client.iverksett
 
-import no.nav.dagpenger.kontrakter.iverksett.IverksettDto
 import no.nav.tiltakspenger.utbetaling.client.iverksett.IverksettKlient.Response
+import no.nav.utsjekk.kontrakter.iverksett.IverksettDto
 
 interface Iverksett {
     suspend fun iverksett(iverksettDto: IverksettDto): Response

--- a/src/main/kotlin/no/nav/tiltakspenger/utbetaling/client/iverksett/IverksettKlient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/utbetaling/client/iverksett/IverksettKlient.kt
@@ -12,10 +12,10 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import mu.KotlinLogging
-import no.nav.dagpenger.kontrakter.iverksett.IverksettDto
 import no.nav.tiltakspenger.utbetaling.Configuration
 import no.nav.tiltakspenger.utbetaling.auth.defaultHttpClient
 import no.nav.tiltakspenger.utbetaling.auth.defaultObjectMapper
+import no.nav.utsjekk.kontrakter.iverksett.IverksettDto
 
 private val log = KotlinLogging.logger {}
 

--- a/src/main/kotlin/no/nav/tiltakspenger/utbetaling/service/UtbetalingServiceImpl.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/utbetaling/service/UtbetalingServiceImpl.kt
@@ -1,13 +1,5 @@
 package no.nav.tiltakspenger.utbetaling.service
 
-import no.nav.dagpenger.kontrakter.felles.BrukersNavKontor
-import no.nav.dagpenger.kontrakter.felles.Personident
-import no.nav.dagpenger.kontrakter.felles.StønadTypeTiltakspenger
-import no.nav.dagpenger.kontrakter.iverksett.ForrigeIverksettingDto
-import no.nav.dagpenger.kontrakter.iverksett.IverksettDto
-import no.nav.dagpenger.kontrakter.iverksett.StønadsdataTiltakspengerDto
-import no.nav.dagpenger.kontrakter.iverksett.UtbetalingDto
-import no.nav.dagpenger.kontrakter.iverksett.VedtaksdetaljerDto
 import no.nav.tiltakspenger.utbetaling.client.iverksett.IverksettKlient
 import no.nav.tiltakspenger.utbetaling.client.iverksett.IverksettKlient.Response
 import no.nav.tiltakspenger.utbetaling.domene.BehandlingId
@@ -23,6 +15,14 @@ import no.nav.tiltakspenger.utbetaling.domene.antallBarn
 import no.nav.tiltakspenger.utbetaling.domene.nyttUtbetalingVedtak
 import no.nav.tiltakspenger.utbetaling.repository.VedtakRepo
 import no.nav.tiltakspenger.utbetaling.routes.utbetaling.GrunnlagDTO
+import no.nav.utsjekk.kontrakter.felles.BrukersNavKontor
+import no.nav.utsjekk.kontrakter.felles.Personident
+import no.nav.utsjekk.kontrakter.felles.StønadTypeTiltakspenger
+import no.nav.utsjekk.kontrakter.iverksett.ForrigeIverksettingDto
+import no.nav.utsjekk.kontrakter.iverksett.IverksettDto
+import no.nav.utsjekk.kontrakter.iverksett.StønadsdataTiltakspengerDto
+import no.nav.utsjekk.kontrakter.iverksett.UtbetalingDto
+import no.nav.utsjekk.kontrakter.iverksett.VedtaksdetaljerDto
 import java.time.LocalDate
 
 class UtbetalingServiceImpl(

--- a/src/test/kotlin/no/nav/tiltakspenger/utbetaling/client/iverksett/IverksettKlientTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/utbetaling/client/iverksett/IverksettKlientTest.kt
@@ -3,11 +3,11 @@ package no.nav.tiltakspenger.utbetaling.client.iverksett
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import kotlinx.coroutines.test.runTest
-import no.nav.dagpenger.kontrakter.felles.Personident
-import no.nav.dagpenger.kontrakter.iverksett.IverksettDto
-import no.nav.dagpenger.kontrakter.iverksett.VedtaksdetaljerDto
 import no.nav.tiltakspenger.utbetaling.domene.BehandlingId
 import no.nav.tiltakspenger.utbetaling.domene.SakId
+import no.nav.utsjekk.kontrakter.felles.Personident
+import no.nav.utsjekk.kontrakter.iverksett.IverksettDto
+import no.nav.utsjekk.kontrakter.iverksett.VedtaksdetaljerDto
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.time.LocalDateTime

--- a/src/test/kotlin/no/nav/tiltakspenger/utbetaling/service/UtbetalingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/utbetaling/service/UtbetalingServiceTest.kt
@@ -2,9 +2,6 @@ package no.nav.tiltakspenger.utbetaling.service
 
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import no.nav.dagpenger.kontrakter.felles.StønadTypeTiltakspenger
-import no.nav.dagpenger.kontrakter.iverksett.StønadsdataTiltakspengerDto
-import no.nav.dagpenger.kontrakter.iverksett.UtbetalingDto
 import no.nav.tiltakspenger.utbetaling.domene.SakId
 import no.nav.tiltakspenger.utbetaling.domene.Satser
 import no.nav.tiltakspenger.utbetaling.domene.TiltakType
@@ -14,6 +11,9 @@ import no.nav.tiltakspenger.utbetaling.domene.UtfallForPeriode
 import no.nav.tiltakspenger.utbetaling.domene.Utfallsperiode
 import no.nav.tiltakspenger.utbetaling.domene.Vedtak
 import no.nav.tiltakspenger.utbetaling.domene.VedtakId
+import no.nav.utsjekk.kontrakter.felles.StønadTypeTiltakspenger
+import no.nav.utsjekk.kontrakter.iverksett.StønadsdataTiltakspengerDto
+import no.nav.utsjekk.kontrakter.iverksett.UtbetalingDto
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime


### PR DESCRIPTION
Kontraktene finnes nå her: https://github.com/navikt/utsjekk-kontrakter
